### PR TITLE
Use qrexec service argument for component name

### DIFF
--- a/github-webhooks/trigger-build
+++ b/github-webhooks/trigger-build
@@ -55,7 +55,7 @@ def handle(obj):
             print(str(e), file=sys.stderr)
             return
         for vm in build_vms:
-            qrexec(vm, 'qubesbuilder.TriggerBuild', repo_name + '\n')
+            qrexec(vm, 'qubesbuilder.TriggerBuild+' + repo_name)
     except KeyError:
         pass
 

--- a/rpc-services/qubesbuilder.TriggerBuild
+++ b/rpc-services/qubesbuilder.TriggerBuild
@@ -3,15 +3,17 @@
 # Service called from network-exposed VM (probably sys-net) into actual build
 # VM to (potentially) trigger a build when a properly signed version tag is
 # being pushed.
-# The only thing on the service input is component name. Then each
+# The only thing in service argument is component name. Then each
 # qubes-builder instance (if multiple of them) will check if actually git
 # repository (branch configured in builder.conf) contains new version tag at
 # the top.
 
-read untrusted_component_name
-# that's the only thing we read from the caller, make sure we don't accidentally
-# read anything else - close stdin
+# Don't read anything from standard input
 exec </dev/null
+
+untrusted_component_name="$1"
+shift
+
 # also, don't return anything; log it locally, just in case
 mkdir -p $HOME/builder-github-logs
 log_basename="$HOME/builder-github-logs/$(date +%s)-$$"


### PR DESCRIPTION
This leverages qrexec implementation for initial sanitization (don't
allow non-ASCII chars, '/', spaces etc). Later may be also useful for
some fine-grained policy.

Suggested by @jpouellet