### PR TITLE
Add new "Build-template" command handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+dist: trusty
+language: shell
+script:
+ - shellcheck rpc-services/* lib/*
+
+branches:
+  except:
+    - /.*_.*/

--- a/Makefile.github
+++ b/Makefile.github
@@ -6,9 +6,6 @@ update-repo-from-snapshot: release_name_dist_tmp = $(word 3,$(pkg_filter))_$(wor
 update-repo-from-snapshot: release_name_dist = $(subst $(coma),,$(subst $(bracket),,$(release_name_dist_tmp)))
 update-repo-from-snapshot: notify-github
 
-notify-github: repo_words=$(subst /, ,$(UPDATE_REPO))
-notify-github: repo_type=$(word $(shell expr $(words $(repo_words)) - 2),$(repo_words))
-notify-github: release_name=$(word $(shell expr $(words $(repo_words)) - 3),$(repo_words))
 ifneq (,$(findstring $(DISTRIBUTION), fedora centos))
 notify-github: pkg_name=$(basename $(basename $(notdir $(firstword $(packages)))))
 else ifneq (,$(findstring $(DISTRIBUTION), debian qubuntu))
@@ -20,10 +17,10 @@ endif
 notify-github:
 	[ -z "$(pkg_name)" ] || $(BUILDER_GITHUB_DIR)/notify-issues \
 		--build-log="$(BUILD_LOG_URL)" \
-		"$(release_name)" \
-		"$(repo_type)" \
+		"r$(RELEASE)" \
+		"$(TARGET_REPO)" \
 		"$(ORIG_SRC)" \
 		"$(pkg_name)" \
 		"$(DIST)" \
 		"$(PACKAGE_SET)" \
-		"$(GITHUB_STATE_DIR)/$(release_name)-$(COMPONENT)-$(PACKAGE_SET)-$(DIST)-$(repo_type)"
+		"$(GITHUB_STATE_DIR)/r$(RELEASE)-$(COMPONENT)-$(PACKAGE_SET)-$(DIST)-$(TARGET_REPO)"

--- a/Makefile.github
+++ b/Makefile.github
@@ -17,10 +17,11 @@ endif
 notify-github:
 	[ -z "$(pkg_name)" ] || $(BUILDER_GITHUB_DIR)/notify-issues \
 		--build-log="$(BUILD_LOG_URL)" \
+		upload \
 		"r$(RELEASE)" \
-		"$(TARGET_REPO)" \
 		"$(ORIG_SRC)" \
 		"$(pkg_name)" \
 		"$(DIST)" \
 		"$(PACKAGE_SET)" \
+		"$(TARGET_REPO)" \
 		"$(GITHUB_STATE_DIR)/r$(RELEASE)-$(COMPONENT)-$(PACKAGE_SET)-$(DIST)-$(TARGET_REPO)"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ GPG keyring with public keys allowed to sign repository action commands (see bel
 Commands in github issues comments
 ----------------------------------
 
+### Upload command ###
+
 Issues created in repository pointed by `GITHUB_BUILD_REPORT_REPO` have one
 more purpose. Can be used to control when packages should be moved from testing
 (`current-testing`) to stable (`current`) repository. This can be achieved by
@@ -80,6 +82,30 @@ Parameters:
     codename (like `fc25`), separated with `-`; for example `dom0-fc23` or
     `vm-jessie`.
 
+Command needs to be signed with key for which public part is in
+`~/.config/qubes-builder-github/trusted-keys-for-commands.gpg` keyring.
+
+### Build-template command ###
+
+One can use Build-template command to start a template build. A command
+consists of one line in form:
+
+    "Build-template" release_name dist timestamp
+
+(words in quotes should be used verbatim - without quotes, others are parameters)
+
+Parameters:
+
+  - `release_name` - name of release, like `r3.2`; must match name used in
+    `builders.list` configuration and name used in updates repositories
+    (apt/yum/...)
+  - `dist` - template code name, as defined in builder.conf, `DISTS_VM` option;
+    only values listed in `DISTS_VM` (for particular builder instance) are
+    allowed
+  - `timestamp` - timestamp part of template version, in form `%Y%m%d%H%M`, UTC
+    (for example `201806281345`); must be not older than 1h and not greater
+    than 5 minutes into the future
+  
 Command needs to be signed with key for which public part is in
 `~/.config/qubes-builder-github/trusted-keys-for-commands.gpg` keyring.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Installation
         GITHUB_BUILD_REPORT_REPO = QubesOS/updates-status
 
 2. (optional) Place rpc services in `/usr/local/etc/qubes-rpc` directory of
-   build VM. There are two services:
+   build VM. Also, copy (or symlink) `lib` directory to
+   `/usr/local/lib/qubes-builder-github`. There are two services:
 
 - `qubesbuilder.TriggerBuild`: Trigger a build for a given component. The
    service will check if configured branch (according to `builder.conf`) have

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ GPG keyring with public keys allowed to sign repository action commands (see bel
 Commands in github issues comments
 ----------------------------------
 
+`qubesbuilder.ProcessGithubCommand` rpc service can respond to GPG-signed
+commands, for example sent as a comment on (some) github issue. Each such
+command needs to be properly inline GPG signed, with a key included in
+`~/.config/qubes-builder-github/trusted-keys-for-commands.gpg`. The service
+does not try to validate where such comment is placed, it trusts only signed
+content of the comment (this is conscious design decision).
+Additionally, set `ALLOWED_DISTS_fingerprint` option in `builder.conf` (replace
+`fingerprint` with actual full key fingerprint) to list what
+distribution can be controlled with a given key. Include `dom0` word to grant
+access also to dom0 packages. You can set it to `$(DISTS_VM) dom0`, to allow
+everything, regardless of actual `DISTS_VM` value.
+
 ### Upload command ###
 
 Issues created in repository pointed by `GITHUB_BUILD_REPORT_REPO` have one

--- a/builder.conf
+++ b/builder.conf
@@ -1,0 +1,25 @@
+template-in-dispvm: $(DISTS_VM:%=pre-template-build-notify-%)
+
+pre-template-build-notify-%: DIST=$*
+pre-template-build-notify-%:
+	TEMPLATE_NAME=$$(MAKEFLAGS= DIST=$(DIST) $(MAKE) -s \
+			-C $(SRC_DIR)/linux-template-builder template-name); \
+	TEMPLATE_VERSION=$$(cat \
+			$(SRC_DIR)/linux-template-builder/version); \
+	[ -n "$$TEMPLATE_TIMESTAMP" ] || \
+		export TEMPLATE_TIMESTAMP=$$(date -u +%Y%m%d%H%M); \
+	export DIST_ORIG_ALIAS=$$(MAKEFLAGS= $(MAKE) -s \
+			-f Makefile.generic \
+			COMPONENT=linux-template-builder \
+			DIST=$(DIST) \
+			get-var \
+			GET_VAR=DIST_ORIG_ALIAS); \
+	$(SRC_DIR)/builder-github/notify-issues \
+		build-start \
+		"r$(RELEASE)" \
+		"$(SRC_DIR)/linux-template-builder" \
+		"qubes-template-$$TEMPLATE_NAME-$$TEMPLATE_VERSION-$$TEMPLATE_TIMESTAMP" \
+		"$(DIST)" \
+		"vm"
+
+# vim: ft=make

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+
+###
+### Common setup
+###
+
+# load list of qubes-builder instances
+config_file="$HOME/.config/qubes-builder-github/builders.list"
+
+# don't return anything; log it locally, just in case
+mkdir -p $HOME/builder-github-logs
+log_basename="$HOME/builder-github-logs/$(date +%s)-$$"
+exec >>${log_basename}.log 2>&1
+
+tmpdir=$(mktemp -d)
+# setup cleanup
+trap "rm -rf $tmpdir" EXIT
+
+###
+### Common functions for qubes-builder-github scripts
+###
+
+# read clearsign-ed command from stdin, verify against keys in $1, then write
+# it to the file pointed by $2.
+# The script will close stdin to be sure no other (untrusted) data is obtained.
+read_stdin_command_and_verify_signature() {
+    local keyring_path="$1"
+    local output_file="$2"
+
+    if ! [ -r "$keyring_path" ]; then
+        echo "Keyring $keyring_path does not exist" >&2
+        return 1
+    fi
+
+    if ! [ -d "$tmpdir" ]; then
+        echo "Temporary dir $tmpdir does not exist" >&2
+        return 1
+    fi
+
+    # this will read from standard input of the service, the data should be
+    # considered untrusted
+    tr -d '\r' | awk -b \
+            -v in_command=0 \
+            -v in_signature=0 \
+            -v output_data="$tmpdir/untrusted_command.tmp" \
+            -v output_sig="$tmpdir/untrusted_command.sig" \
+            '
+        /^-----BEGIN PGP SIGNED MESSAGE-----$/ {
+            # skip first 3 lines (this one, hash declaration and empty line)
+            in_command=4
+        }
+        /^-----BEGIN PGP SIGNATURE-----$/ {
+            in_command=0
+            in_signature=1
+        }
+        {
+            if (in_command > 1) {
+                in_command--
+                next
+            }
+        }
+        {
+            if (in_command) print >output_data
+            if (in_signature) print >output_sig
+        }
+        /^-----END PGP SIGNATURE-----$/ {
+            in_signature=0
+        }
+    '
+
+    # make sure we don't read anything else from stdin
+    exec </dev/null
+
+    if [ ! -r "$tmpdir/untrusted_command.tmp" -o \
+         ! -r "$tmpdir/untrusted_command.sig" ]; then
+        echo "Missing parts of gpg signature" >&2
+        exit 1
+    fi
+
+    # gpg --clearsign apparently ignore trailing newline while calculating hash. So
+    # must do the same here for signature verification. This is stupid.
+    head -c -1 "$tmpdir/untrusted_command.tmp" > "$tmpdir/untrusted_command"
+
+    if ! gpgv2 --keyring "$keyring_path" \
+            "$tmpdir/untrusted_command.sig" \
+            "$tmpdir/untrusted_command"; then
+        echo "Invalid signature" >&2
+        exit 1
+    fi
+
+    # now, take the first line of already verified file
+    head -n 1 "$tmpdir/untrusted_command" > "$output_file"
+    # add trailing newline back
+    echo "" >> "$output_file"
+
+    # log the command
+    echo -n "Command: " >&2
+    cat "$output_file" >&2
+}
+
+
+# Execute command given in $1 for each configured builder instance, in
+# parallel, but only one instance will be running in given builder instance
+# (the command will be called with builder.lock held).
+# The command will be called with 2 arguments:
+#  - release name (like r3.2)
+#  - builder instance path
+execute_in_each_builder() {
+    local cmd="$1"
+
+    # look for a builder instance(s) for this release
+    IFS="="
+    while read config_release_name builder_dir; do
+        if ! [ -d "$builder_dir" ]; then
+            continue
+        fi
+
+        # at this point it's important to have only one instance running (and no build
+        # process running), so take a lock; also go into background, as this may take
+        # some time
+        (
+            exec 9> "$builder_dir/builder.lock"
+            flock -x 9
+
+            # don't read $config_file (stdin for 'while' loop) and also don't mix
+            # the output
+            exec >>"${log_basename}-${config_release_name}.log" 2>&1 </dev/null
+
+            $cmd "$config_release_name" "$builder_dir"
+
+        ) &
+
+    done < "$config_file"
+}

--- a/lib/github-command-build-template
+++ b/lib/github-command-build-template
@@ -5,13 +5,15 @@
 #
 # First argument is expected to be a command file path, already
 # verified against trusted keys set. 
+# Second argument is a key fingerprint used to sign the command
 
-if [ $# -lt 1 ]; then
-    echo "Usage: $0 <command-file>" >&2
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <command-file> <key-fingerprint>" >&2
     exit 1
 fi
 
 command_file="$1"
+signer_fpr="$2"
 
 scripts_dir="/usr/local/lib/qubes-builder-github"
 
@@ -70,9 +72,15 @@ build_template_for_release() {
     supported_dists=$(make --no-print-directory -C "$local_builder_dir" \
             TEMPLATE_ALIAS= \
             get-var GET_VAR=DISTS_VM)
+    allowed_dists=$(get_allowed_dists "$local_builder_dir" "$signer_fpr")
 
     if ! echo " $supported_dists " | grep -q " $dist "; then
         # not listed in this builder instance
+        return
+    fi
+
+    if ! echo " $allowed_dists " | grep -q " $dist "; then
+        # not allowed here
         return
     fi
 

--- a/lib/github-command-build-template
+++ b/lib/github-command-build-template
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+# Script called by qubesbuilder.ProcessGithubCommand for handling "Build-template"
+# command
+#
+# First argument is expected to be a command file path, already
+# verified against trusted keys set. 
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <command-file>" >&2
+    exit 1
+fi
+
+command_file="$1"
+
+scripts_dir="/usr/local/lib/qubes-builder-github"
+
+# shellcheck source=lib/functions.sh
+. "$scripts_dir/functions.sh"
+
+read -r action release_name dist timestamp \
+        < "$command_file"
+
+if [ "x$action" != "xBuild-template" ]; then
+    echo "Invalid action" >&2
+    exit 1
+fi
+
+case "${dist}" in
+    *[/.$IFS]*)
+        echo "Forbidden character in dist" >&2
+        exit 1
+        ;;
+    "")
+        echo "Empty dist" >&2
+        exit 1
+        ;;
+esac
+
+
+# release_name verified in build_template_for_release function
+# dist verified in build_template_for_release function
+
+if ! printf "%s" "$timestamp" | grep -q "^[0-9]\{12\}$"; then
+    echo "Invalid timestamp format" >&2
+    exit 1
+fi
+
+timestamp_format="%Y%m%d%H%M"
+timestamp_max=$(date -u -d '+5 min' +$timestamp_format)
+timestamp_min=$(date -u -d '-1 hour' +$timestamp_format)
+if [ "$timestamp" -gt "$timestamp_max" ] || \
+        [ "$timestamp" -lt "$timestamp_min" ]; then
+    echo "Timestamp outside of allowed range" >&2
+    exit 1
+fi
+
+# enable logging (use qrexec policy to redirect to the right VM)
+export QUBES_BUILD_LOG_CMD="qrexec-client-vm 'dom0' qubesbuilder.BuildLog"
+
+build_template_for_release() {
+    local_config_release_name="$1"
+    local_builder_dir="$2"
+
+    if [ "$local_config_release_name" != "$release_name" ]; then
+        return
+    fi
+
+    # get DISTS_VM as configured in builder.conf, without resolving aliases yet
+    supported_dists=$(make --no-print-directory -C "$local_builder_dir" \
+            TEMPLATE_ALIAS= \
+            get-var GET_VAR=DISTS_VM)
+
+    if ! echo " $supported_dists " | grep -q " $dist "; then
+        # not listed in this builder instance
+        return
+    fi
+
+    # $dist verified to be in DISTS_VM, now check BUILDER_TEMPLATE_CONF; for
+    # that $dist must be translated via TEMPLATE_ALIAS
+    dist_translated=$(DISTS_VM=$dist \
+            make --no-print-directory -C "$local_builder_dir" \
+            get-var GET_VAR=DISTS_VM)
+    builder_template_conf=$(make --no-print-directory -C "$local_builder_dir" \
+            get-var GET_VAR=BUILDER_TEMPLATE_CONF)
+    if ! echo " $builder_template_conf"|grep -q " $dist_translated:"; then
+        # template config not set
+        return
+    fi
+
+    "$local_builder_dir/scripts/auto-build-template" \
+        "$dist" "$timestamp"
+}
+
+execute_in_each_builder build_template_for_release

--- a/lib/github-command-upload
+++ b/lib/github-command-upload
@@ -47,7 +47,12 @@ case "${dists_and_end}" in
         ;;
 esac
 
-if [ "x$repo_name" != "xcurrent" ] && [ "x$repo_name" != "xsecurity-testing" ]; then
+if [ "x${component}" = "xlinux-template-builder" ]; then
+    if [ "x$repo_name" != "xtemplates-itl" ] && [ "x$repo_name" != "xtemplates-community" ]; then
+        echo "Unsupported target repo" >&2
+        exit 1
+    fi
+elif [ "x$repo_name" != "xcurrent" ] && [ "x$repo_name" != "xsecurity-testing" ]; then
     echo "Unsupported target repo" >&2
     exit 1
 fi
@@ -69,14 +74,18 @@ upload_for_release() {
         return 0
     fi
 
-    actual_commit_sha=$(git -C "$local_builder_dir/qubes-src/$component" rev-parse HEAD)
-    if [ "x$commit_sha" != "x$actual_commit_sha" ]; then
-        echo "Repository have changed in the meantime (current: $actual_commit_sha)" >&2
-        return 1
+    # for templates verify for each separately
+    if [ "$component" != "linux-template-builder" ]; then
+        actual_commit_sha=$(git -C "$local_builder_dir/qubes-src/$component" rev-parse HEAD)
+        if [ "x$commit_sha" != "x$actual_commit_sha" ]; then
+            echo "Repository have changed in the meantime (current: $actual_commit_sha)" >&2
+            return 1
+        fi
     fi
 
-    # if no specific distribution was requested, upload all of them
-    if [ "x$dists_and_end" = "xrepo" ]; then
+    # if no specific distribution was requested, upload all of them, unless template
+    if [ "$component" != "linux-template-builder" ] && \
+            [ "x$dists_and_end" = "xrepo" ]; then
         COMPONENTS="$component" \
         "$local_builder_dir/scripts/make-with-log" \
             "update-repo-$repo_name"
@@ -88,8 +97,18 @@ upload_for_release() {
     requested_dists_vm=
     supported_dists_dom0=$(make --no-print-directory -C "$local_builder_dir" \
             get-var GET_VAR=DIST_DOM0)
-    supported_dists_vm=$(make --no-print-directory -C "$local_builder_dir" \
-            get-var GET_VAR=DISTS_VM_NO_FLAVOR)
+    if [ "$component" = "linux-template-builder" ]; then
+        # for templates force original DIST_DOM0 ...
+        requested_dists_dom0="$supported_dists_dom0"
+        supported_dists_dom0=
+        # ... and DISTS_VM including flavors
+        supported_dists_vm=$(make --no-print-directory -C "$local_builder_dir" \
+                TEMPLATE_ALIAS= \
+                get-var GET_VAR=DISTS_VM)
+    else
+        supported_dists_vm=$(make --no-print-directory -C "$local_builder_dir" \
+                get-var GET_VAR=DISTS_VM_NO_FLAVOR)
+    fi
     IFS=' '
     for dist_pair in $dists_and_end; do
         package_set=${dist_pair%%-*}
@@ -101,6 +120,19 @@ upload_for_release() {
             # don't fail otherwise - maybe builder in other VM will handle it
         elif [ "x$package_set" = "xvm" ]; then
             if echo " $supported_dists_vm " | grep -q " $dist "; then
+                # for templates verify its version here
+                if [ "$component" = "linux-template-builder" ]; then
+                    template_name=$(DISTS_VM="$dist" make -s -C "$local_builder_dir" \
+                        template-name)
+                    build_version=$(cat \
+                        "$local_builder_dir/qubes-src/linux-template-builder/version")
+                    build_timestamp=$(cat \
+                        "$local_builder_dir/qubes-src/linux-template-builder/build_timestamp_$template_name")
+                    if [ "$commit_sha" != "$build_version-$build_timestamp" ]; then
+                        echo "Different template was built in the meantime (current: $build_version-$build_timestamp)" >&2
+                        return 1
+                    fi
+                fi
                 requested_dists_vm="$requested_dists_vm $dist"
             fi
             # don't fail otherwise - maybe builder in other VM will handle it

--- a/lib/github-command-upload
+++ b/lib/github-command-upload
@@ -5,13 +5,15 @@
 #
 # First argument is expected to be a command file path, already
 # verified against trusted keys set.
+# Second argument is a key fingerprint used to sign the command
 
-if [ $# -lt 1 ]; then
-    echo "Usage: $0 <command-file>" >&2
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <command-file> <key-fingerprint>" >&2
     exit 1
 fi
 
 command_file="$1"
+signer_fpr="$2"
 
 scripts_dir="/usr/local/lib/qubes-builder-github"
 
@@ -83,9 +85,18 @@ upload_for_release() {
         fi
     fi
 
+    allowed_dists=$(get_allowed_dists "$local_builder_dir" "$signer_fpr")
+
     # if no specific distribution was requested, upload all of them, unless template
     if [ "$component" != "linux-template-builder" ] && \
             [ "x$dists_and_end" = "xrepo" ]; then
+        dom0_opt=
+        if [ "${allowed_dists% dom0}" = "$allowed_dists" ]; then
+            # exclude dom0
+            dom0_opt="DIST_DOM0="
+        fi
+        DISTS_VM="${allowed_dists% dom0}" \
+        $dom0_opt \
         COMPONENTS="$component" \
         "$local_builder_dir/scripts/make-with-log" \
             "update-repo-$repo_name"
@@ -102,12 +113,16 @@ upload_for_release() {
         requested_dists_dom0="$supported_dists_dom0"
         supported_dists_dom0=
         # ... and DISTS_VM including flavors
-        supported_dists_vm=$(make --no-print-directory -C "$local_builder_dir" \
-                TEMPLATE_ALIAS= \
-                get-var GET_VAR=DISTS_VM)
+        supported_dists_vm="${allowed_dists% dom0}"
     else
-        supported_dists_vm=$(make --no-print-directory -C "$local_builder_dir" \
+        # otherwise resolve aliases and cut out flavors
+        supported_dists_vm=$(DISTS_VM="${allowed_dists% dom0}" \
+                make --no-print-directory -C "$local_builder_dir" \
                 get-var GET_VAR=DISTS_VM_NO_FLAVOR)
+    fi
+    # exclude dom0 if not allowed
+    if [ "${allowed_dists% dom0}" = "$allowed_dists" ]; then
+        supported_dists_dom0=
     fi
     IFS=' '
     for dist_pair in $dists_and_end; do

--- a/lib/github-command-upload
+++ b/lib/github-command-upload
@@ -1,0 +1,127 @@
+#!/bin/sh
+
+# Script called by qubesbuilder.ProcessGithubCommand for handling "Upload"
+# command
+#
+# First argument is expected to be a command file path, already
+# verified against trusted keys set. 
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <command-file>" >&2
+    exit 1
+fi
+
+command_file="$1"
+
+scripts_dir="/usr/local/lib/qubes-builder-github"
+
+. "$scripts_dir/functions.sh"
+
+read action component commit_sha release_name repo_name dists_and_end \
+        < "$command_file"
+
+if [ "x$action" != "xUpload" ]; then
+    echo "Invalid action" >&2
+    exit 1
+fi
+
+case "${component}" in
+    *[/.$IFS]*)
+        echo "Forbidden character in component name" >&2
+        exit 1
+        ;;
+    "")
+        echo "Empty component name" >&2
+        exit 1
+        ;;
+esac
+
+case "${dists_and_end}" in
+    *repo)
+        # ok
+        ;;
+    *)
+        echo "Missing 'repo' and the command end" >&2
+        exit 1
+        ;;
+esac
+
+if [ "x$repo_name" != "xcurrent" -a "x$repo_name" != "xsecurity-testing" ]; then
+    echo "Unsupported target repo" >&2
+    exit 1
+fi
+
+# enable logging (use qrexec policy to redirect to the right VM)
+export QUBES_BUILD_LOG_CMD="qrexec-client-vm 'dom0' qubesbuilder.BuildLog"
+
+upload_for_release() {
+    local config_release_name="$1"
+    local builder_dir="$2"
+
+    if [ "$config_release_name" != "$release_name" ]; then
+        return
+    fi
+
+    if ! [ -d "$builder_dir/qubes-src/$component" ]; then
+        echo "Component $component not found in $builder_dir" >&2
+        # maybe it's in another VM?
+        return 0
+    fi
+
+    actual_commit_sha=$(git -C "$builder_dir/qubes-src/$component" rev-parse HEAD)
+    if [ "x$commit_sha" != "x$actual_commit_sha" ]; then
+        echo "Repository have changed in the meantime (current: $actual_commit_sha)" >&2
+        return 1
+    fi
+
+    # if no specific distribution was requested, upload all of them
+    if [ "x$dists_and_end" == "xrepo" ]; then
+        COMPONENTS="$component" \
+        "$builder_dir/scripts/make-with-log" \
+            update-repo-$repo_name
+        return $?
+    fi
+
+    # otherwise, process repositories list
+    requested_dists_dom0=
+    requested_dists_vm=
+    supported_dists_dom0=$(make -C "$builder_dir" get-var GET_VAR=DIST_DOM0)
+    supported_dists_vm=$(make -C "$builder_dir" get-var GET_VAR=DISTS_VM_NO_FLAVOR)
+    for dist_pair in $dists_and_end; do
+        package_set=${dist_pair%%-*}
+        dist=${dist_pair#*-}
+        if [ "x$package_set" == "xdom0" ]; then
+            if echo " $supported_dists_dom0 " | grep -q " $dist "; then
+                requested_dists_dom0="$requested_dists_dom0 $dist"
+            fi
+            # don't fail otherwise - maybe builder in other VM will handle it
+        elif [ "x$package_set" == "xvm" ]; then
+            if echo " $supported_dists_vm " | grep -q " $dist "; then
+                requested_dists_vm="$requested_dists_vm $dist"
+            fi
+            # don't fail otherwise - maybe builder in other VM will handle it
+        elif [ "x$dist_pair" == "xrepo" ]; then
+            # end processing here
+            break
+        fi
+    done
+
+    # strip leading spaces
+    read requested_dists_vm <<EOF
+$requested_dists_vm
+EOF
+    read requested_dists_dom0 <<EOF
+$requested_dists_dom0
+EOF
+
+    if [ -n "$requested_dists_vm" -o -n "$requested_dists_dom0" ]; then
+        COMPONENTS="$component" \
+        DISTS_VM="$requested_dists_vm" \
+        DIST_DOM0="$requested_dists_dom0" \
+        "$builder_dir/scripts/make-with-log" \
+            update-repo-$repo_name
+        return $?
+    fi
+}
+
+execute_in_each_builder upload_for_release

--- a/lib/github-command-upload
+++ b/lib/github-command-upload
@@ -4,7 +4,7 @@
 # command
 #
 # First argument is expected to be a command file path, already
-# verified against trusted keys set. 
+# verified against trusted keys set.
 
 if [ $# -lt 1 ]; then
     echo "Usage: $0 <command-file>" >&2
@@ -15,9 +15,10 @@ command_file="$1"
 
 scripts_dir="/usr/local/lib/qubes-builder-github"
 
+# shellcheck source=lib/functions.sh
 . "$scripts_dir/functions.sh"
 
-read action component commit_sha release_name repo_name dists_and_end \
+read -r action component commit_sha release_name repo_name dists_and_end \
         < "$command_file"
 
 if [ "x$action" != "xUpload" ]; then
@@ -46,7 +47,7 @@ case "${dists_and_end}" in
         ;;
 esac
 
-if [ "x$repo_name" != "xcurrent" -a "x$repo_name" != "xsecurity-testing" ]; then
+if [ "x$repo_name" != "xcurrent" ] && [ "x$repo_name" != "xsecurity-testing" ]; then
     echo "Unsupported target repo" >&2
     exit 1
 fi
@@ -55,74 +56,74 @@ fi
 export QUBES_BUILD_LOG_CMD="qrexec-client-vm 'dom0' qubesbuilder.BuildLog"
 
 upload_for_release() {
-    local config_release_name="$1"
-    local builder_dir="$2"
+    local_config_release_name="$1"
+    local_builder_dir="$2"
 
-    if [ "$config_release_name" != "$release_name" ]; then
+    if [ "$local_config_release_name" != "$release_name" ]; then
         return
     fi
 
-    if ! [ -d "$builder_dir/qubes-src/$component" ]; then
-        echo "Component $component not found in $builder_dir" >&2
+    if ! [ -d "$local_builder_dir/qubes-src/$component" ]; then
+        echo "Component $component not found in $local_builder_dir" >&2
         # maybe it's in another VM?
         return 0
     fi
 
-    actual_commit_sha=$(git -C "$builder_dir/qubes-src/$component" rev-parse HEAD)
+    actual_commit_sha=$(git -C "$local_builder_dir/qubes-src/$component" rev-parse HEAD)
     if [ "x$commit_sha" != "x$actual_commit_sha" ]; then
         echo "Repository have changed in the meantime (current: $actual_commit_sha)" >&2
         return 1
     fi
 
     # if no specific distribution was requested, upload all of them
-    if [ "x$dists_and_end" == "xrepo" ]; then
+    if [ "x$dists_and_end" = "xrepo" ]; then
         COMPONENTS="$component" \
-        "$builder_dir/scripts/make-with-log" \
-            update-repo-$repo_name
+        "$local_builder_dir/scripts/make-with-log" \
+            "update-repo-$repo_name"
         return $?
     fi
 
     # otherwise, process repositories list
     requested_dists_dom0=
     requested_dists_vm=
-    supported_dists_dom0=$(make --no-print-directory -C "$builder_dir" \
+    supported_dists_dom0=$(make --no-print-directory -C "$local_builder_dir" \
             get-var GET_VAR=DIST_DOM0)
-    supported_dists_vm=$(make --no-print-directory -C "$builder_dir" \
+    supported_dists_vm=$(make --no-print-directory -C "$local_builder_dir" \
             get-var GET_VAR=DISTS_VM_NO_FLAVOR)
     IFS=' '
     for dist_pair in $dists_and_end; do
         package_set=${dist_pair%%-*}
         dist=${dist_pair#*-}
-        if [ "x$package_set" == "xdom0" ]; then
+        if [ "x$package_set" = "xdom0" ]; then
             if echo " $supported_dists_dom0 " | grep -q " $dist "; then
                 requested_dists_dom0="$requested_dists_dom0 $dist"
             fi
             # don't fail otherwise - maybe builder in other VM will handle it
-        elif [ "x$package_set" == "xvm" ]; then
+        elif [ "x$package_set" = "xvm" ]; then
             if echo " $supported_dists_vm " | grep -q " $dist "; then
                 requested_dists_vm="$requested_dists_vm $dist"
             fi
             # don't fail otherwise - maybe builder in other VM will handle it
-        elif [ "x$dist_pair" == "xrepo" ]; then
+        elif [ "x$dist_pair" = "xrepo" ]; then
             # end processing here
             break
         fi
     done
 
     # strip leading spaces
-    read requested_dists_vm <<EOF
+    read -r requested_dists_vm <<EOF
 $requested_dists_vm
 EOF
-    read requested_dists_dom0 <<EOF
+    read -r requested_dists_dom0 <<EOF
 $requested_dists_dom0
 EOF
 
-    if [ -n "$requested_dists_vm" -o -n "$requested_dists_dom0" ]; then
+    if [ -n "$requested_dists_vm$requested_dists_dom0" ]; then
         COMPONENTS="$component" \
         DISTS_VM="$requested_dists_vm" \
         DIST_DOM0="$requested_dists_dom0" \
-        "$builder_dir/scripts/make-with-log" \
-            update-repo-$repo_name
+        "$local_builder_dir/scripts/make-with-log" \
+            "update-repo-$repo_name"
         return $?
     fi
 }

--- a/lib/github-command-upload
+++ b/lib/github-command-upload
@@ -85,8 +85,11 @@ upload_for_release() {
     # otherwise, process repositories list
     requested_dists_dom0=
     requested_dists_vm=
-    supported_dists_dom0=$(make -C "$builder_dir" get-var GET_VAR=DIST_DOM0)
-    supported_dists_vm=$(make -C "$builder_dir" get-var GET_VAR=DISTS_VM_NO_FLAVOR)
+    supported_dists_dom0=$(make --no-print-directory -C "$builder_dir" \
+            get-var GET_VAR=DIST_DOM0)
+    supported_dists_vm=$(make --no-print-directory -C "$builder_dir" \
+            get-var GET_VAR=DISTS_VM_NO_FLAVOR)
+    IFS=' '
     for dist_pair in $dists_and_end; do
         package_set=${dist_pair%%-*}
         dist=${dist_pair#*-}

--- a/message-build-report-template
+++ b/message-build-report-template
@@ -1,0 +1,8 @@
+Template @TEMPLATE_NAME@ @VERSION@ for Qubes @RELEASE_NAME@, see comments below for details.
+
+If you're release manager, you can issue GPG-inline signed command (depending on template):
+
+* `Upload linux-template-builder @VERSION@ @RELEASE_NAME@ templates-itl vm-@DIST@ repo` (available 7 days from now)
+* `Upload linux-template-builder @VERSION@ @RELEASE_NAME@ templates-community vm-@DIST@ repo` (available 7 days from now)
+
+Above commands will work only if package in testing repository isn't superseded by newer version.

--- a/notify-issues
+++ b/notify-issues
@@ -137,10 +137,16 @@ def search_or_create_issue(github_repo, release, component,
         if not create:
             return None
 
-        message_template_path = os.path.join(
-            os.path.dirname(sys.argv[0]),
-            'message-build-report'
-        )
+        if component.startswith('qubes-template'):
+            message_template_path = os.path.join(
+                os.path.dirname(sys.argv[0]),
+                'message-build-report-template'
+            )
+        else:
+            message_template_path = os.path.join(
+                os.path.dirname(sys.argv[0]),
+                'message-build-report'
+            )
         if not os.path.exists(message_template_path):
             print "WARNING: {} does not exist".format(message_template_path)
             return None
@@ -336,23 +342,35 @@ def notify_build_report(args, dist_label, repo_type, commit_sha,
             prefix=github_repo_prefix,
             repo=component)
 
-    version, previous_version, shortlog, referenced_issues_txt = \
-         get_package_changes(args.src_dir, git_url, commit_sha)
+    if component == 'linux-template-builder':
+        # qubes-template-fedora-25-4.0.0-201710170053
+        version = '-'.join(args.package_name.split('-')[-2:])
+        component = '-'.join(args.package_name.split('-')[:-2])
+        template_name = component.replace('qubes-template-', '')
+        message_kwargs = {
+            '@COMMIT_SHA@': commit_sha,
+            '@GIT_URL@': git_url,
+            '@TEMPLATE_NAME@': template_name,
+            '@DIST@': os.getenv('DIST_ORIG_ALIAS', '(dist)'),
+        }
+    else:
+        version, previous_version, shortlog, referenced_issues_txt = \
+             get_package_changes(args.src_dir, git_url, commit_sha)
 
-    git_log_url = \
-        "{git_url}/compare/{prev_commit}...{curr_commit}".format(
-            git_url=git_url,
-            prev_commit=previous_version,
-            curr_commit=version
-        )
+        git_log_url = \
+            "{git_url}/compare/{prev_commit}...{curr_commit}".format(
+                git_url=git_url,
+                prev_commit=previous_version,
+                curr_commit=version
+            )
 
-    message_kwargs = {
-        '@COMMIT_SHA@': commit_sha,
-        '@GIT_URL@': git_url,
-        '@GIT_LOG@': shortlog,
-        '@GIT_LOG_URL@': git_log_url,
-        '@ISSUES@': referenced_issues_txt
-    }
+        message_kwargs = {
+            '@COMMIT_SHA@': commit_sha,
+            '@GIT_URL@': git_url,
+            '@GIT_LOG@': shortlog,
+            '@GIT_LOG_URL@': git_log_url,
+            '@ISSUES@': referenced_issues_txt
+        }
 
     report_issue_no = search_or_create_issue(
         github_report_repo, args.release_name, component,
@@ -374,7 +392,9 @@ def main():
     parser.add_argument("repo_type",
                         help="Repository type",
                         choices=['current', 'current-testing',
-                                 'security-testing', 'unstable'])
+                                 'security-testing', 'unstable',
+                                 'templates-itl', 'templates-itl-testing',
+                                 'templates-community', 'templates-community-testing'])
     parser.add_argument("src_dir",
                         help="Component sources path")
     parser.add_argument("package_name",
@@ -402,6 +422,7 @@ def main():
     delete_labels = []
     add_labels = []
     dist_label = args.dist
+    repo_type = args.repo_type
     if args.package_set == 'dom0':
         dist_label = 'dom0'
     if args.repo_type == 'current':
@@ -411,10 +432,13 @@ def main():
         add_labels = ["{}-{}-stable".format(args.release_name, dist_label)]
     elif args.repo_type == 'current-testing':
         add_labels = ["{}-{}-cur-test".format(args.release_name, dist_label)]
-        repo_type = 'current-testing'
     elif args.repo_type == 'security-testing':
         add_labels = ["{}-{}-sec-test".format(args.release_name, dist_label)]
-        repo_type = 'security-testing'
+    elif args.repo_type == 'templates-itl':
+        delete_labels = ["{}-testing".format(args.release_name)]
+        add_labels = ["{}-stable".format(args.release_name)]
+    elif args.repo_type == 'templates-itl-testing':
+        add_labels = ["{}-testing".format(args.release_name)]
     else:
         print "Ignoring {}".format(args.repo_type)
         return

--- a/notify-issues
+++ b/notify-issues
@@ -248,6 +248,64 @@ def notify_closed_issues(args, repo_type,
 
         comment_issue(issue, message, add_labels, delete_labels)
 
+def get_package_changes(src_dir, git_url, commit_sha):
+    ''' Returns a tuple of:
+        - current version
+        - previous verion
+        - git short log formatted with github links
+        - referenced github issues, in github syntax
+    '''
+    git_proc = subprocess.Popen(
+        ['git', '-C', src_dir, 'tag', '--list', '--points-at=HEAD', 'v*'],
+        stdout=subprocess.PIPE)
+    (version_tags, _) = git_proc.communicate()
+    version = version_tags.splitlines()[0]
+
+    # get previous version
+    git_proc = subprocess.Popen(
+        ['git', '-C', src_dir, 'describe', '--match',
+            'v*', '--abbrev=0', commit_sha + '~'],
+        stdout=subprocess.PIPE)
+    (version_tags, _) = git_proc.communicate()
+    if not version_tags:
+        # if no previous version tag, check from (some) root commit
+        git_proc = subprocess.Popen(
+            ['git', '-C', src_dir, 'rev-list', '--max-parents=0',
+                commit_sha + '~'],
+            stdout=subprocess.PIPE)
+        (version_tags, _) = git_proc.communicate()
+
+    previous_version = version_tags.splitlines()[0]
+
+    git_log_proc = subprocess.Popen(
+        ['git', '-C', src_dir, 'log', '{}..{}'.format(previous_version,
+            version)],
+        stdout=subprocess.PIPE)
+
+    (git_log, _) = git_log_proc.communicate()
+    referenced_issues = []
+    for line in git_log.splitlines():
+        match = issue_re.search(line)
+        if match:
+            issues_string = match.group(0)
+            issues_numbers = [int(cleanup_re.sub("", s))
+                for s in issues_string.split()]
+            referenced_issues.extend(issues_numbers)
+
+    referenced_issues_txt = '\n'.join(
+        'QubesOS/qubes-issues#{}'.format(x) for x in set(referenced_issues))
+
+    github_full_repo_name = '/'.join(git_url.split('/')[-2:])
+
+    git_log_proc = subprocess.Popen(
+        ['git', '-C', args.src_dir, 'log',
+         '--pretty=format:{}@%h %s'.format(
+             github_full_repo_name),
+         '{}..{}'.format(previous_version, version)],
+        stdout=subprocess.PIPE)
+    (shortlog, _) = git_log_proc.communicate()
+
+    return version, previous_version, shortlog, referenced_issues_txt
 
 def notify_build_report(args, dist_label, repo_type, commit_sha,
         add_labels, delete_labels):
@@ -268,70 +326,25 @@ def notify_build_report(args, dist_label, repo_type, commit_sha,
             "Package for {dist} was uploaded to {repo_type} repository".format(
                 dist=dist_label, repo_type=repo_type)
 
-    git_proc = subprocess.Popen(
-        ['git', '-C', args.src_dir, 'tag', '--list', '--points-at=HEAD', 'v*'],
-        stdout=subprocess.PIPE)
-    (version_tags, _) = git_proc.communicate()
-    version = version_tags.splitlines()[0]
-
-    # get previous version
-    git_proc = subprocess.Popen(
-        ['git', '-C', args.src_dir, 'describe', '--match',
-            'v*', '--abbrev=0', commit_sha + '~'],
-        stdout=subprocess.PIPE)
-    (version_tags, _) = git_proc.communicate()
-    if not version_tags:
-        # if no previous version tag, check from (some) root commit
-        git_proc = subprocess.Popen(
-            ['git', '-C', args.src_dir, 'rev-list', '--max-parents=0',
-                commit_sha + '~'],
-            stdout=subprocess.PIPE)
-        (version_tags, _) = git_proc.communicate()
-
-    previous_version = version_tags.splitlines()[0]
-
-    git_log_proc = subprocess.Popen(
-        ['git', '-C', args.src_dir, 'log', '{}..{}'.format(previous_version,
-                                                           version)],
-        stdout=subprocess.PIPE)
-
-    (git_log, _) = git_log_proc.communicate()
-    referenced_issues = []
-    for line in git_log.splitlines():
-        match = issue_re.search(line)
-        if match:
-            issues_string = match.group(0)
-            issues_numbers = [int(cleanup_re.sub("", s))
-                for s in issues_string.split()]
-            referenced_issues.extend(issues_numbers)
-
-    referenced_issues_txt = '\n'.join(
-        'QubesOS/qubes-issues#{}'.format(x) for x in set(referenced_issues))
-
-    git_url_var = 'GIT_URL_' + os.path.basename(args.src_dir).replace('-', '_')
+    component = os.path.basename(args.src_dir)
+    git_url_var = 'GIT_URL_' + component.replace('-', '_')
     if git_url_var in os.environ:
         git_url = os.environ[git_url_var]
     else:
         git_url = "{base}/{prefix}{repo}".format(
             base=github_baseurl,
             prefix=github_repo_prefix,
-            repo=os.path.basename(args.src_dir))
+            repo=component)
+
+    version, previous_version, shortlog, referenced_issues_txt = \
+         get_package_changes(args.src_dir, git_url, commit_sha)
+
     git_log_url = \
         "{git_url}/compare/{prev_commit}...{curr_commit}".format(
             git_url=git_url,
             prev_commit=previous_version,
             curr_commit=version
         )
-
-    github_full_repo_name = '/'.join(git_url.split('/')[-2:])
-
-    git_log_proc = subprocess.Popen(
-        ['git', '-C', args.src_dir, 'log',
-         '--pretty=format:{}@%h %s'.format(
-             github_full_repo_name),
-         '{}..{}'.format(previous_version, version)],
-        stdout=subprocess.PIPE)
-    (shortlog, _) = git_log_proc.communicate()
 
     message_kwargs = {
         '@COMMIT_SHA@': commit_sha,
@@ -342,7 +355,7 @@ def notify_build_report(args, dist_label, repo_type, commit_sha,
     }
 
     report_issue_no = search_or_create_issue(
-        github_report_repo, args.release_name, os.environ['COMPONENT'],
+        github_report_repo, args.release_name, component,
         version=version,
         create=True, message_template_kwargs=message_kwargs)
     if report_issue_no:

--- a/notify-issues
+++ b/notify-issues
@@ -319,7 +319,9 @@ def notify_build_report(args, dist_label, repo_type, commit_sha,
         return
 
     github_report_repo = os.environ['GITHUB_BUILD_REPORT_REPO']
-    if args.build_log:
+    if args.command == 'build-start':
+        report_message = None
+    elif args.build_log:
         report_message = \
             "Package for {dist} was built ([build log]({build_log})) and " \
             "uploaded to {repo_type} repository".format(
@@ -376,7 +378,7 @@ def notify_build_report(args, dist_label, repo_type, commit_sha,
         github_report_repo, args.release_name, component,
         version=version,
         create=True, message_template_kwargs=message_kwargs)
-    if report_issue_no:
+    if report_issue_no and args.command == 'upload':
         comment_issue(report_issue_no, report_message,
             add_labels, delete_labels, github_repo=github_report_repo)
 
@@ -387,29 +389,46 @@ def main():
              "current state is recorded"
 
     parser = ArgumentParser(epilog=epilog)
-    parser.add_argument("release_name",
+    parser.add_argument("--auth-token",
+                        help="Github authentication token (OAuth2)")
+    parser.add_argument("--build-log",
+                        help="Build log name in build-logs repository")
+    subparsers = parser.add_subparsers(help='command')
+    upload_parser = subparsers.add_parser('upload')
+    upload_parser.set_defaults(command='upload')
+    upload_parser.add_argument("release_name",
                         help="Release name, for example r3.0")
-    parser.add_argument("repo_type",
+    upload_parser.add_argument("src_dir",
+                        help="Component sources path")
+    upload_parser.add_argument("package_name",
+                        help="Binary package name")
+    upload_parser.add_argument("dist",
+                        help="Distribution release code name")
+    upload_parser.add_argument("package_set",
+                        choices=['dom0', 'vm'])
+    upload_parser.add_argument("repo_type",
                         help="Repository type",
                         choices=['current', 'current-testing',
                                  'security-testing', 'unstable',
                                  'templates-itl', 'templates-itl-testing',
                                  'templates-community', 'templates-community-testing'])
-    parser.add_argument("src_dir",
-                        help="Component sources path")
-    parser.add_argument("package_name",
-                        help="Binary package name")
-    parser.add_argument("dist",
-                        help="Distribution release code name")
-    parser.add_argument("package_set",
-                        choices=['dom0', 'vm'])
-    parser.add_argument("state_file",
+    upload_parser.add_argument("state_file",
                         help="File to store internal state (previous commit "
                              "id)")
-    parser.add_argument("--auth-token",
-                        help="Github authentication token (OAuth2)")
-    parser.add_argument("--build-log",
-                        help="Build log name in build-logs repository")
+
+    build_parser = subparsers.add_parser('build-start')
+    build_parser.set_defaults(command='build-start')
+    build_parser.add_argument("release_name",
+                        help="Release name, for example r3.0")
+    build_parser.add_argument("src_dir",
+                        help="Component sources path")
+    build_parser.add_argument("package_name",
+                        help="Binary package name")
+    build_parser.add_argument("dist",
+                        help="Distribution release code name")
+    build_parser.add_argument("package_set",
+                        choices=['dom0', 'vm'])
+
     args = parser.parse_args()
 
     if args.auth_token:
@@ -419,29 +438,35 @@ def main():
         auth_headers['Authorization'] = \
             'token {}'.format(os.environ['GITHUB_API_KEY'])
 
-    delete_labels = []
-    add_labels = []
     dist_label = args.dist
-    repo_type = args.repo_type
     if args.package_set == 'dom0':
         dist_label = 'dom0'
-    if args.repo_type == 'current':
-        repo_type = 'stable'
-        delete_labels = ["{}-{}-cur-test".format(args.release_name, dist_label),
-                        "{}-{}-sec-test".format(args.release_name, dist_label)]
-        add_labels = ["{}-{}-stable".format(args.release_name, dist_label)]
-    elif args.repo_type == 'current-testing':
-        add_labels = ["{}-{}-cur-test".format(args.release_name, dist_label)]
-    elif args.repo_type == 'security-testing':
-        add_labels = ["{}-{}-sec-test".format(args.release_name, dist_label)]
-    elif args.repo_type == 'templates-itl':
-        delete_labels = ["{}-testing".format(args.release_name)]
-        add_labels = ["{}-stable".format(args.release_name)]
-    elif args.repo_type == 'templates-itl-testing':
-        add_labels = ["{}-testing".format(args.release_name)]
+
+    if args.command == 'upload':
+        delete_labels = []
+        add_labels = []
+        repo_type = args.repo_type
+        if args.repo_type == 'current':
+            repo_type = 'stable'
+            delete_labels = ["{}-{}-cur-test".format(args.release_name, dist_label),
+                            "{}-{}-sec-test".format(args.release_name, dist_label)]
+            add_labels = ["{}-{}-stable".format(args.release_name, dist_label)]
+        elif args.repo_type == 'current-testing':
+            add_labels = ["{}-{}-cur-test".format(args.release_name, dist_label)]
+        elif args.repo_type == 'security-testing':
+            add_labels = ["{}-{}-sec-test".format(args.release_name, dist_label)]
+        elif args.repo_type == 'templates-itl':
+            delete_labels = ["{}-testing".format(args.release_name)]
+            add_labels = ["{}-stable".format(args.release_name)]
+        elif args.repo_type == 'templates-itl-testing':
+            add_labels = ["{}-testing".format(args.release_name)]
+        else:
+            print "Ignoring {}".format(args.repo_type)
+            return
     else:
-        print "Ignoring {}".format(args.repo_type)
-        return
+        add_labels = []
+        delete_labels = []
+        repo_type = None
 
     if not release_name_re.match(args.release_name):
         print "Ignoring release {}".format(args.release_name)
@@ -452,21 +477,23 @@ def main():
         stdout=subprocess.PIPE)
     (current_commit, _) = git_proc.communicate()
     current_commit = current_commit.strip()
-    if not os.path.exists(args.state_file):
-        print "WARNING: {} does not exist, initializing with the " \
-              "current state".format(args.state_file)
-        previous_commit = None
-    else:
-        with open(args.state_file, 'r') as f:
-            previous_commit = f.readline().strip()
 
-    if previous_commit is not None:
-        if repo_type in ['stable', 'current-testing']:
-            notify_closed_issues(args, repo_type, current_commit,
-                previous_commit, add_labels, delete_labels)
+    if args.command == 'upload':
+        if not os.path.exists(args.state_file):
+            print "WARNING: {} does not exist, initializing with the " \
+                  "current state".format(args.state_file)
+            previous_commit = None
+        else:
+            with open(args.state_file, 'r') as f:
+                previous_commit = f.readline().strip()
 
-    with open(args.state_file, 'w') as f:
-        f.write(current_commit)
+        if previous_commit is not None:
+            if repo_type in ['stable', 'current-testing']:
+                notify_closed_issues(args, repo_type, current_commit,
+                    previous_commit, add_labels, delete_labels)
+
+        with open(args.state_file, 'w') as f:
+            f.write(current_commit)
 
     notify_build_report(args, dist_label, repo_type, current_commit,
         add_labels, delete_labels)

--- a/rpc-services/qubesbuilder.ProcessGithubCommand
+++ b/rpc-services/qubesbuilder.ProcessGithubCommand
@@ -7,6 +7,9 @@
 # Service input should consists of inline GPG-signed message with just one line:
 #
 #    "Upload" component_name commit_sha release_name "current" (dists) "repo"
+# or
+#
+#    "Build-template" dist timestamp
 #
 # (words in quotes are verbatim - without quotes, others are parameters)
 # Also, instead of "current", "security-testing" value is supported too.
@@ -30,6 +33,9 @@ read -r action args < "$tmpdir/command"
 case "$action" in
     Upload)
         "$scripts_dir/github-command-upload" "$tmpdir/command"
+        ;;
+    Build-template)
+        "$scripts_dir/github-command-build-template" "$tmpdir/command"
         ;;
     *)
         echo "Unknown command $action" >&2

--- a/rpc-services/qubesbuilder.ProcessGithubCommand
+++ b/rpc-services/qubesbuilder.ProcessGithubCommand
@@ -194,7 +194,7 @@ while read config_release_name builder_dir; do
         read requested_dists_vm <<EOF
 $requested_dists_vm
 EOF
-        requested_dists_dom0 <<EOF
+        read requested_dists_dom0 <<EOF
 $requested_dists_dom0
 EOF
 

--- a/rpc-services/qubesbuilder.ProcessGithubCommand
+++ b/rpc-services/qubesbuilder.ProcessGithubCommand
@@ -25,17 +25,18 @@ scripts_dir="/usr/local/lib/qubes-builder-github"
 # shellcheck source=lib/functions.sh
 . "$scripts_dir/functions.sh"
 
-read_stdin_command_and_verify_signature "$keyring_path" "$tmpdir/command"
+command_signer=
+read_stdin_command_and_verify_signature "$keyring_path" "$tmpdir/command" command_signer
 
 # shellcheck disable=SC2034
 read -r action args < "$tmpdir/command"
 
 case "$action" in
     Upload)
-        "$scripts_dir/github-command-upload" "$tmpdir/command"
+        "$scripts_dir/github-command-upload" "$tmpdir/command" "$command_signer"
         ;;
     Build-template)
-        "$scripts_dir/github-command-build-template" "$tmpdir/command"
+        "$scripts_dir/github-command-build-template" "$tmpdir/command" "$command_signer"
         ;;
     *)
         echo "Unknown command $action" >&2

--- a/rpc-services/qubesbuilder.ProcessGithubCommand
+++ b/rpc-services/qubesbuilder.ProcessGithubCommand
@@ -19,11 +19,13 @@ keyring_path="$HOME/.config/qubes-builder-github/trusted-keys-for-commands.gpg"
 
 scripts_dir="/usr/local/lib/qubes-builder-github"
 
+# shellcheck source=lib/functions.sh
 . "$scripts_dir/functions.sh"
 
 read_stdin_command_and_verify_signature "$keyring_path" "$tmpdir/command"
 
-read action args < "$tmpdir/command"
+# shellcheck disable=SC2034
+read -r action args < "$tmpdir/command"
 
 case "$action" in
     Upload)

--- a/rpc-services/qubesbuilder.ProcessGithubCommand
+++ b/rpc-services/qubesbuilder.ProcessGithubCommand
@@ -16,196 +16,21 @@
 set -e
 
 keyring_path="$HOME/.config/qubes-builder-github/trusted-keys-for-commands.gpg"
-# load list of qubes-builder instances
-config_file="$HOME/.config/qubes-builder-github/builders.list"
 
-# enable logging (use qrexec policy to redirect to the right VM)
-export QUBES_BUILD_LOG_CMD="qrexec-client-vm 'dom0' qubesbuilder.BuildLog"
+scripts_dir="/usr/local/lib/qubes-builder-github"
 
-# don't return anything; log it locally, just in case
-mkdir -p $HOME/builder-github-logs
-log_basename="$HOME/builder-github-logs/$(date +%s)-$$"
-exec >>${log_basename}.log 2>&1
+. "$scripts_dir/functions.sh"
 
-tmpdir=$(mktemp -d)
-# setup cleanup
-trap "rm -rf $tmpdir" EXIT
+read_stdin_command_and_verify_signature "$keyring_path" "$tmpdir/command"
 
-# this will read from standard input of the service, the data should be
-# considered untrusted
-tr -d '\r' | awk -b \
-        -v in_command=0 \
-        -v in_signature=0 \
-        -v output_data="$tmpdir/untrusted_command.tmp" \
-        -v output_sig="$tmpdir/untrusted_command.sig" \
-        '
-    /^-----BEGIN PGP SIGNED MESSAGE-----$/ {
-        # skip first 3 lines (this one, hash declaration and empty line)
-        in_command=4
-    }
-    /^-----BEGIN PGP SIGNATURE-----$/ {
-        in_command=0
-        in_signature=1
-    }
-    {
-        if (in_command > 1) {
-            in_command--
-            next
-        }
-    }
-    {
-        if (in_command) print >output_data
-        if (in_signature) print >output_sig
-    }
-    /^-----END PGP SIGNATURE-----$/ {
-        in_signature=0
-    }
-'
+read action args < "$tmpdir/command"
 
-# make sure we don't read anything else from stdin
-exec </dev/null
-
-if [ ! -r "$tmpdir/untrusted_command.tmp" -o \
-     ! -r "$tmpdir/untrusted_command.sig" ]; then
-    echo "Missing parts of gpg signature" >&2
-    exit 1
-fi
-
-# gpg --clearsign apparently ignore trailing newline while calculating hash. So
-# must do the same here for signature verification. This is stupid.
-head -c -1 "$tmpdir/untrusted_command.tmp" > "$tmpdir/untrusted_command"
-
-if ! gpgv2 --keyring "$keyring_path" "$tmpdir/untrusted_command.sig" "$tmpdir/untrusted_command"; then
-    echo "Invalid signature" >&2
-    exit 1
-fi
-
-# now, take the first line of already verified file
-head -n 1 "$tmpdir/untrusted_command" > "$tmpdir/command"
-# add trailing newline back
-echo "" >> "$tmpdir/command"
-
-# log the command
-echo -n "Command: " >&2
-cat "$tmpdir/command" >&2
-
-read action component commit_sha release_name repo_name dists_and_end \
-        < "$tmpdir/command"
-
-if [ "x$action" != "xUpload" ]; then
-    echo "Unsupported action" >&2
-    exit 1
-fi
-
-case "${component}" in
-    *[/.$IFS]*)
-        echo "Forbidden character in component name" >&2
-        exit 1
-        ;;
-    "")
-        echo "Empty component name" >&2
-        exit 1
-        ;;
-esac
-
-case "${dists_and_end}" in
-    *repo)
-        # ok
+case "$action" in
+    Upload)
+        "$scripts_dir/github-command-upload" "$tmpdir/command"
         ;;
     *)
-        echo "Missing 'repo' and the command end" >&2
+        echo "Unknown command $action" >&2
         exit 1
         ;;
 esac
-
-if [ "x$repo_name" != "xcurrent" -a "x$repo_name" != "xsecurity-testing" ]; then
-    echo "Unsupported target repo" >&2
-    exit 1
-fi
-
-# look for a builder instance(s) for this release
-IFS="="
-while read config_release_name builder_dir; do
-
-    if [ "$config_release_name" != "$release_name" ]; then
-        continue
-    fi
-
-    if ! [ -d "$builder_dir" ]; then
-        continue
-    fi
-
-    # at this point it's important to have only one instance running (and no build
-    # process running), so take a lock; also go into background, as this may take
-    # some time
-    (
-        exec 9> "$builder_dir/builder.lock"
-        flock -x 9
-
-        if ! [ -d "$builder_dir/qubes-src/$component" ]; then
-            echo "Component $component not found in $builder_dir" >&2
-            # maybe it's in another VM?
-            exit 0
-        fi
-
-        # don't read $config_file (stdin for 'while' loop) and also don't mix
-        # the output
-        exec >>"${log_basename}-${release_name}.log" 2>&1 </dev/null
-
-        actual_commit_sha=$(git -C "$builder_dir/qubes-src/$component" rev-parse HEAD)
-        if [ "x$commit_sha" != "x$actual_commit_sha" ]; then
-            echo "Repository have changed in the meantime (current: $actual_commit_sha)" >&2
-            exit 1
-        fi
-
-        # if no specific distribution was requested, upload all of them
-        if [ "x$dists_and_end" == "xrepo" ]; then
-            COMPONENTS="$component" \
-            "$builder_dir/scripts/make-with-log" \
-                update-repo-$repo_name
-            exit $?
-        fi
-
-        # otherwise, process repositories list
-        requested_dists_dom0=
-        requested_dists_vm=
-        supported_dists_dom0=$(make -C "$builder_dir" get-var GET_VAR=DIST_DOM0)
-        supported_dists_vm=$(make -C "$builder_dir" get-var GET_VAR=DISTS_VM_NO_FLAVOR)
-        for dist_pair in $dists_and_end; do
-            package_set=${dist_pair%%-*}
-            dist=${dist_pair#*-}
-            if [ "x$package_set" == "xdom0" ]; then
-                if echo " $supported_dists_dom0 " | grep -q " $dist "; then
-                    requested_dists_dom0="$requested_dists_dom0 $dist"
-                fi
-                # don't fail otherwise - maybe builder in other VM will handle it
-            elif [ "x$package_set" == "xvm" ]; then
-                if echo " $supported_dists_vm " | grep -q " $dist "; then
-                    requested_dists_vm="$requested_dists_vm $dist"
-                fi
-                # don't fail otherwise - maybe builder in other VM will handle it
-            elif [ "x$dist_pair" == "xrepo" ]; then
-                # end processing here
-                break
-            fi
-        done
-
-        # strip leading spaces
-        read requested_dists_vm <<EOF
-$requested_dists_vm
-EOF
-        read requested_dists_dom0 <<EOF
-$requested_dists_dom0
-EOF
-
-        if [ -n "$requested_dists_vm" -o -n "$requested_dists_dom0" ]; then
-            COMPONENTS="$component" \
-            DISTS_VM="$requested_dists_vm" \
-            DIST_DOM0="$requested_dists_dom0" \
-            "$builder_dir/scripts/make-with-log" \
-                update-repo-$repo_name
-            exit $?
-        fi
-    ) &
-
-done < "$config_file"

--- a/rpc-services/qubesbuilder.TriggerBuild
+++ b/rpc-services/qubesbuilder.TriggerBuild
@@ -15,9 +15,9 @@ untrusted_component_name="$1"
 shift
 
 # also, don't return anything; log it locally, just in case
-mkdir -p $HOME/builder-github-logs
+mkdir -p "$HOME/builder-github-logs"
 log_basename="$HOME/builder-github-logs/$(date +%s)-$$"
-exec >>${log_basename}.log 2>&1
+exec >>"${log_basename}.log" 2>&1
 
 # validate component name - forbid '/', '.' and space
 case "${untrusted_component_name}" in
@@ -42,7 +42,7 @@ if ! [ -r "$config_file" ]; then
 fi
 
 IFS="="
-while read release_name builder_dir; do
+while read -r release_name builder_dir; do
     component=
     if ! [ -d "$builder_dir" ]; then
         continue;
@@ -57,7 +57,7 @@ while read release_name builder_dir; do
         component_repo=$(basename "$component_url" .git)
         # strip 'qubes-' prefix, if any
         component_repo=${component_repo#qubes-}
-        if [ "$component" == "$untrusted_component_name" ] || 
+        if [ "$component" == "$untrusted_component_name" ] ||
                 [ "$component_repo" == "$untrusted_component_name" ]; then
             # Start a build process in subprocess (allow parallel builds in different
             # builders) and with a lock for this builder (don't allow multiple components


### PR DESCRIPTION
Support for new "Build-template" signed command for remote triggering template
build. The command takes release name, template name and timestamp part of
desired version. The build process is started in a DispVM (only templates with
config file defined explicitly are allowed). In addition, now it's possible to
define what distributions can be controlled with which key.
Contrary to normal packages, there
is also notification about build start (the updates-status issue is created at
the beginning, not the end of the process), as it can take a long time.

This also include various code cleanup and refactoring to keep the code
reasonably easy to understand.

Fixes QubesOS/qubes-issues#3935