### PR TITLE
Nicer styling for the package status page

### DIFF
--- a/templates/status-head.html
+++ b/templates/status-head.html
@@ -15,6 +15,8 @@ td.templates-community { background-color: green; }
 td.days-testing { background-color: yellow; }
 td.days-stable { background-color: green; }
 td.no-version { background-color: red; font-weight: bold; }
+td, th { border: solid 2px #dcdcdc; padding: 4px; }
+table { border-collapse: collapse; }
 </style>
   </head>
   <body>

--- a/templates/status-head.html
+++ b/templates/status-head.html
@@ -2,6 +2,7 @@
   <head>
     <title>Packages status</title>
 <style>
+body { font-family: sans-serif; }
 td.current { background-color: green; }
 td.current-testing { background-color: yellow; }
 td.templates-itl-testing { background-color: yellow; }


### PR DESCRIPTION
This is of course subjective, but I think it looks at least a little nicer.

Before:

![Screenshot_2019-03-28_13-42-14](https://user-images.githubusercontent.com/911174/55181100-56b6aa00-5161-11e9-8051-2711aa2a95ee.png)

After:

![Screenshot_2019-03-28_13-41-48](https://user-images.githubusercontent.com/911174/55181114-5fa77b80-5161-11e9-9f6f-025added92ff.png)

Note that those screenshots are about the same height - I added padding to the cells so they didn't feel as cramped with the border.