### PR TITLE
Miscellaneous builder hardening

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -56,6 +56,7 @@ read_stdin_command_and_verify_signature() {
             print msg > "/dev/stderr"
             exit 1
         }
+        length($0) > 256 { fail("line too long"); }
         /[^A-Za-z0-9_.+/ -]/ { fail("junk character in string"); }
         /^-----BEGIN PGP SIGNED MESSAGE-----$/ {
             # skip first 3 lines (this one, hash declaration and empty line)

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -43,7 +43,9 @@ read_stdin_command_and_verify_signature() {
 
     # this will read from standard input of the service, the data should be
     # considered untrusted
-    tr -d '\r' | awk -b \
+    LC_ALL=C head -c 4096 |
+    LC_ALL=C tr -d '\r' |
+    LC_ALL=C awk -b \
             -v in_command=0 \
             -v in_signature=0 \
             -v output_data="$tmpdir/untrusted_command.tmp" \

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -82,7 +82,7 @@ read_stdin_command_and_verify_signature() {
             if (in_signature) print >output_sig
         }
         /^-----END PGP SIGNATURE-----$/ {
-            in_signature=0
+            exit
         }
     '
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -114,9 +114,9 @@ read_stdin_command_and_verify_signature() {
 
     # extract signer fingerprint
     if [ -n "$local_signer" ]; then
-        eval "$local_signer"="$(grep -Po \
+        eval "$local_signer"="'$(grep -Po \
             '^\[GNUPG:\] VALIDSIG (([0-9A-F-]+ ){9}|)\K([0-9A-F]*)' \
-            "$tmpdir/gpg-status")"
+            "$tmpdir/gpg-status")'"
     fi
     rm -f "$tmpdir/gpg-status"
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -44,7 +44,6 @@ read_stdin_command_and_verify_signature() {
     # this will read from standard input of the service, the data should be
     # considered untrusted
     LC_ALL=C head -c 4096 |
-    LC_ALL=C tr -d '\r' |
     LC_ALL=C tr '\0' '\001' |
     LC_ALL=C awk -b \
             -v in_command=0 \

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -75,12 +75,17 @@ read_stdin_command_and_verify_signature() {
         }
         {
             if (in_command) {
-                if (command_too_long) { fail("extra lines in command") }
-                # gpg --clearsign apparently ignore trailing newline while
-                # calculating hash. So must do the same here for signature
-                # verification. This is stupid.
-                printf "%s", $0 >output_data;
-                command_too_long = 1;
+                if (command_too_long) {
+                    fail("extra lines in command")
+                } else if (/^[A-Za-z0-9_. -]+$/) {
+                    # gpg --clearsign apparently ignore trailing newline while
+                    # calculating hash. So must do the same here for signature
+                    # verification. This is stupid.
+                    printf "%s", $0 >output_data;
+                    command_too_long = 1;
+                } else {
+                    fail("Bad character in command");
+                }
             }
             if (in_signature) print >output_sig
         }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -49,6 +49,7 @@ read_stdin_command_and_verify_signature() {
     LC_ALL=C awk -b \
             -v in_command=0 \
             -v in_signature=0 \
+            -v command_too_long=0 \
             -v output_data="$tmpdir/untrusted_command.tmp" \
             -v output_sig="$tmpdir/untrusted_command.sig" \
             '
@@ -73,7 +74,11 @@ read_stdin_command_and_verify_signature() {
             }
         }
         {
-            if (in_command) print >output_data
+            if (in_command) {
+                if (command_too_long) { fail("extra lines in command") }
+                print >output_data;
+                command_too_long = 1;
+            }
             if (in_signature) print >output_sig
         }
         /^-----END PGP SIGNATURE-----$/ {

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -45,12 +45,18 @@ read_stdin_command_and_verify_signature() {
     # considered untrusted
     LC_ALL=C head -c 4096 |
     LC_ALL=C tr -d '\r' |
+    LC_ALL=C tr '\0' '\001' |
     LC_ALL=C awk -b \
             -v in_command=0 \
             -v in_signature=0 \
             -v output_data="$tmpdir/untrusted_command.tmp" \
             -v output_sig="$tmpdir/untrusted_command.sig" \
             '
+        function fail(msg) {
+            print msg > "/dev/stderr"
+            exit 1
+        }
+        /[^A-Za-z0-9_.+/ -]/ { fail("junk character in string"); }
         /^-----BEGIN PGP SIGNED MESSAGE-----$/ {
             # skip first 3 lines (this one, hash declaration and empty line)
             in_command=4

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -44,8 +44,9 @@ read_stdin_command_and_verify_signature() {
     # this will read from standard input of the service, the data should be
     # considered untrusted
     LC_ALL=C head -c 4096 |
-    LC_ALL=C tr '\0' '\001' |
+    LC_ALL=C tr '\000\002' '\001\001' |
     LC_ALL=C awk -b \
+            -F $'\002' \
             -v in_command=0 \
             -v in_signature=0 \
             -v command_too_long=0 \

--- a/rpc-services/qubesbuilder.ProcessGithubCommand
+++ b/rpc-services/qubesbuilder.ProcessGithubCommand
@@ -16,7 +16,7 @@
 #
 # See README.md for detailed description.
 
-set -e
+set -eo pipefail
 
 keyring_path="$HOME/.config/qubes-builder-github/trusted-keys-for-commands.gpg"
 

--- a/rpc-services/qubesbuilder.ProcessGithubCommand
+++ b/rpc-services/qubesbuilder.ProcessGithubCommand
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash --
 
 # Service called from network-exposed VM (probably sys-net) into actual build
 # VM to (potentially) trigger moving packages from current-testing to current

--- a/rpc-services/qubesbuilder.TriggerBuild
+++ b/rpc-services/qubesbuilder.TriggerBuild
@@ -20,6 +20,7 @@ log_basename="$HOME/builder-github-logs/$(date +%s)-$$"
 exec >>"${log_basename}.log" 2>&1
 
 # validate component name - forbid '/', '.' and space
+# note that component name is already somewhat validated by qrexec
 case "${untrusted_component_name}" in
     *[/.\ ]*)
         echo "Forbidden character" >&2

--- a/webhooks/services/process_comment.py
+++ b/webhooks/services/process_comment.py
@@ -47,6 +47,8 @@ class Service:
             if obj['action'] != 'created':
                 return
             comment_body = obj['comment']['body']
+            # strip carriage returns
+            comment_body = comment_body.replace('\r', '')
             # skip comment not having signed part at all
             if '-----BEGIN PGP SIGNED MESSAGE-----' not in comment_body:
                 return

--- a/webhooks/services/process_comment.py
+++ b/webhooks/services/process_comment.py
@@ -47,6 +47,9 @@ class Service:
             if obj['action'] != 'created':
                 return
             comment_body = obj['comment']['body']
+            # check the type of the JSON response
+            if type(comment_body) is not str:
+                return
             # strip carriage returns
             comment_body = comment_body.replace('\r', '')
             # skip comment not having signed part at all

--- a/webhooks/services/process_comment.py
+++ b/webhooks/services/process_comment.py
@@ -53,8 +53,11 @@ class Service:
             # strip carriage returns
             comment_body = comment_body.replace('\r', '')
             # skip comment not having signed part at all
-            if '-----BEGIN PGP SIGNED MESSAGE-----' not in comment_body:
+            try:
+                offset = comment_body.index('-----BEGIN PGP SIGNED MESSAGE-----\nHash: ')
+            except ValueError:
                 return
+            comment_body = comment_body[offset:]
             try:
                 with open(self.config_path) as config:
                     build_vms = config.read().splitlines()


### PR DESCRIPTION
`qubes-builder-github` is exposed to untrusted input from the network, so harden it a bit more.

Not tested because I am not really sure how to test this.